### PR TITLE
Additional-fix-for-BNC-765445

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,11 @@
 ------------------------------------------------------------------
+Wed Jun 20 09:42:53 UTC 2012 - locilka@suse.com
+
+- Additional fix for (BNC #765445). No error reported to stdout
+  even while writing /etc/named.conf without having bind package
+  installed.
+
+------------------------------------------------------------------
 Tue Jun  5 09:04:05 UTC 2012 - locilka@suse.com
 
 - Handling missing /etc/named.conf (BNC #765445)

--- a/src/DnsServer.pm
+++ b/src/DnsServer.pm
@@ -1322,8 +1322,12 @@ sub Write {
     ### Bugzilla #46121, Configuration file changed by hand, INI-Agent would break
     my $new_configuration_timestamp = $self->GetConfigurationStat();
     my $yast2_suffix = ".yast2-save";
+
     # timestamp differs from the Read()
-    if ($new_configuration_timestamp ne $configuration_timestamp) {
+    if (defined $configuration_timestamp
+        and defined $new_configuration_timestamp
+        and $configuration_timestamp ne $new_configuration_timestamp
+    ) {
 	y2warning("Stat of the configuration file was changed during the YaST2 configuration");
 	# moving into yast2-save file
 	my $ret = SCR->Execute (".target.bash_output", "mv --force ".$configfile." ".$configfile.$yast2_suffix);


### PR DESCRIPTION
- No error reported to stdout even while writing /etc/named.conf without having
  bind package installed.
