### PR TITLE
Fixed behavior in build (while running testsuite)

### DIFF
--- a/src/DnsServer.pm
+++ b/src/DnsServer.pm
@@ -967,7 +967,7 @@ sub Read {
     Progress->NextStage ();
 
     # Requires confirmation when NM is used
-    if (! NetworkService->ConfirmNetworkManager()) {
+    if (! Mode->test () && ! NetworkService->ConfirmNetworkManager()) {
 	return 0;
     }
 


### PR DESCRIPTION
- NetworkManager being selected is ignored now
