### PR TITLE
Change the .dns.named agent to be case insensitive

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 18 11:23:54 UTC 2015 - igonzalezsosa@suse.com
+
+- Avoid duplicated lines on /etc/named.conf file
+  (bsc#935129)
+- 3.1.12
+
+-------------------------------------------------------------------
 Fri Feb 13 11:18:34 UTC 2015 - ancor@suse.com
 
 - The unit tests are now compatible with RSpec 3

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        3.1.11
+Version:        3.1.12
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 

--- a/src/scrconf/dns_named.scr
+++ b/src/scrconf/dns_named.scr
@@ -18,7 +18,7 @@
     `IniAgent( "/etc/named.conf",
 	$[
 	    // join_multiline for multiline values without newlines
-	    "options"	: [ "global_values", "repeat_names", "join_multiline" ],
+	    "options"	: [ "global_values", "repeat_names", "join_multiline", "ignore_case" ],
 	    "comments"	: [ "^[ \t]*#.*$", "^[ \t]*$" ],
 	    "params"    : [
 		$[


### PR DESCRIPTION
This PR should fix [bug 935129](https://bugzilla.suse.com/show_bug.cgi?id=935129) as it treats `/etc/named.conf` as case insensitive.