### PR TITLE
Ensures `bind` package is installed before initializing the UI

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug  4 10:24:32 UTC 2016 - igonzalezsosa@suse.com
+
+- Make sure that required 'bind' package is installed before
+  trying to start the UI (bsc#990453)
+- 3.1.23
+
+-------------------------------------------------------------------
 Tue Jun  7 11:28:51 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        3.1.22
+Version:        3.1.23
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,6 +49,10 @@ schemafiles_DATA = \
 desktop_DATA = \
   desktop/dns-server.desktop
 
-EXTRA_DIST = $(module_DATA) $(module1_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(schemafiles_DATA) $(desktop_DATA)
+ylibclientdir = @ylibdir@/lib/dns-server/clients
+ylibclient_DATA = \
+  lib/dns-server/clients/dns_server.rb
+
+EXTRA_DIST = $(module_DATA) $(module1_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(schemafiles_DATA) $(desktop_DATA) $(ylibclient_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/src/clients/dns-server.rb
+++ b/src/clients/dns-server.rb
@@ -1,48 +1,17 @@
 # encoding: utf-8
 
-# File:	clients/dns-server.ycp
-# Package:	Configuration of dns-server
-# Summary:	Main file
-# Authors:	Jiri Srain <jsrain@suse.cz>
-#		Lukas Ocilka <locilka@suse.cz>
+# ------------------------------------------------------------------------------
+# Copyright (c) 2016 SUSE LLC
 #
-# $Id$
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
 #
-# Main file for dns-server configuration. Uses all other files.
-module Yast
-  class DnsServerClient < Client
-    def main
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
 
-      #**
-      # <h3>Configuration of the dns-server</h3>
-
-      textdomain "dns-server"
-      Yast.import "DnsServerUI"
-
-      # The main ()
-      Builtins.y2milestone("----------------------------------------")
-      Builtins.y2milestone("DnsServer module started")
-
-      # main ui function
-      @ret = nil
-
-      # there are some arguments - starting commandline
-      if Ops.greater_than(Builtins.size(WFM.Args), 0)
-        Yast.include self, "dns-server/cmdline.rb" 
-      else
-        @ret = DnsServerUI.DnsSequence
-        Builtins.y2debug("ret=%1", @ret)
-      end
-
-      # Finish
-      Builtins.y2milestone("DnsServer module finished")
-      Builtins.y2milestone("----------------------------------------")
-
-      deep_copy(@ret) 
-
-      # EOF
-    end
-  end
-end
-
+require "dns-server/clients/dns_server"
 Yast::DnsServerClient.new.main

--- a/src/include/dns-server/dialog-main.rb
+++ b/src/include/dns-server/dialog-main.rb
@@ -40,6 +40,9 @@ module Yast
       @initial_screen = "start_up"
 
       @service = SystemdService.find("named")
+
+      raise "Service 'named' not found. Please, install the required packages." unless @service
+
       @status_widget = ::UI::ServiceStatus.new(@service)
 
       @global_options_add_items = Builtins.sort(

--- a/src/lib/dns-server/clients/dns_server.rb
+++ b/src/lib/dns-server/clients/dns_server.rb
@@ -1,0 +1,72 @@
+# encoding: utf-8
+
+# File:	clients/dns-server.ycp
+# Package:	Configuration of dns-server
+# Summary:	Main file
+# Authors:	Jiri Srain <jsrain@suse.cz>
+#		Lukas Ocilka <locilka@suse.cz>
+#
+# $Id$
+#
+# Main file for dns-server configuration. Uses all other files.
+module Yast
+  class DnsServerClient < Client
+    include Yast::Logger
+
+    Yast.import "DnsServer"
+    Yast.import "PackageSystem"
+
+    def main
+
+      #**
+      # <h3>Configuration of the dns-server</h3>
+
+      textdomain "dns-server"
+
+      # The main ()
+      log.info("----------------------------------------")
+      log.info("DnsServer module started")
+
+      # main ui function
+      @ret = nil
+
+      # there are some arguments - starting commandline
+      if Ops.greater_than(Builtins.size(WFM.Args), 0)
+        Yast.include self, "dns-server/cmdline.rb" 
+      else
+        @ret = packages_installed? ? run_sequence : :abort
+        log.debug("ret=#{@ret}")
+      end
+
+      # Finish
+      log.info("DnsServer module finished")
+      log.info("----------------------------------------")
+
+      @ret
+    end
+  end
+
+  # Run DNS sequence
+  #
+  # @return [Symbol] Sequence result
+  def run_sequence
+    Yast.import "DnsServerUI"
+    DnsServerUI.DnsSequence
+  end
+
+  # Checks if required packages are installed
+  #
+  # If package is not installed, asks the user to install it.
+  #
+  # @return [Boolean] true if the package is installed; false if not installed
+  #                   and the user refuses to installed it.
+  def packages_installed?
+    if !PackageSystem.CheckAndInstallPackages(DnsServer.AutoPackages["install"])
+      Popup.Error(_("YaST cannot continue the configuration\n" \
+                    "without installing the required packages"))
+      false
+    else
+      true
+    end
+  end
+end

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,7 +2,8 @@ TESTS = \
   dns_server_test.rb \
   dns_server_ui_test.rb \
   etc_named_parsing_test.rb \
-  masterzone_test.rb
+  masterzone_test.rb \
+  clients/dns_server_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec

--- a/test/clients/dns_server_test.rb
+++ b/test/clients/dns_server_test.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env rspec
+
+require_relative "../test_helper"
+require "dns-server/clients/dns_server"
+
+describe Yast::DnsServerClient do
+  subject(:client) { Yast::DnsServerClient.new }
+
+  let(:dns_server_ui) { double("dns_server_ui").as_null_object }
+  let(:packages) { Yast::DnsServer.AutoPackages["install"] }
+
+  before do
+    allow(Yast).to receive(:import).with("DnsServerUI")
+    allow(dns_server_ui).to receive(:DnsSequence).and_return(:next)
+    stub_const("Yast::DnsServerUI", dns_server_ui)
+  end
+
+  describe "#main" do
+    it "runs DnsSequence and returns its value" do
+     allow(Yast::PackageSystem).to receive(:CheckAndInstallPackages).and_return(true)
+     expect(dns_server_ui).to receive(:DnsSequence).and_return(:next)
+     expect(client.main).to eq(:next)
+    end
+
+    it "makes sure that 'bind' package is installed" do
+      expect(Yast::PackageSystem).to receive(:CheckAndInstallPackages)
+        .with(packages).and_return(true)
+      client.main
+    end
+
+    context "if the user refuses to install the package" do
+      it "shows and error an quits" do
+        expect(Yast::PackageSystem).to receive(:CheckAndInstallPackages)
+          .with(packages).and_return(false)
+        expect(Yast).to_not receive(:Import).with("DnsServerUI")
+        expect(Yast::Popup).to receive(:Error)
+        expect(client.main).to eq(:abort)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Makes sure that `bind` package is installed before initializing the UI (fixes [bsc#990453](https://bugzilla.suse.com/show_bug.cgi?id=990453)).

The problem is that `DnsServerUI` tries to initialize some values when imported and one of those depends on the systemd `named` service. IMHO we could refactor that module's code but, at this point, I think that making sure that the package is available is good enough.

BTW I've moved the client to `lib/dns-server/clients` but without doing further refactors.