### PR TITLE
Make service evaluation lazy

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug  4 11:53:40 UTC 2016 - igonzalezsosa@suse.com
+
+- Fix an Internal Error 'undefined method DnsSequence' in case
+  bind.rpm is not installed (bsc#990453)
+- 3.1.23
+
+-------------------------------------------------------------------
 Tue Jun  7 11:28:51 UTC 2016 - igonzalezsosa@suse.com
 
 - Stop generating autodocs (fate#320356)

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        3.1.22
+Version:        3.1.23
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 


### PR DESCRIPTION
Implements a alternative (and proper) solution to [bsc#990453](https://bugzilla.suse.com/show_bug.cgi?id=990453) as @mvidner suggested instead of the hack I wrote in https://github.com/yast/yast-dns-server/pull/59 :)