### PR TITLE
SuSEFirewall_variables is not exported by SuSEFirewalld.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,6 @@ test-driver
 /test/*.log
 /test/*.trs
 doc/
-.yardoc/*
 coverage/
 .yardoc/
-doc/autodocs
 *.pot

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ pluglib-bindings.ami
 test-driver
 /test/*.log
 /test/*.trs
+doc/
+.yardoc/*
+coverage/
+.yardoc/
+doc/autodocs
+*.pot

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # YaST - The DNS Server Configuration Module #
 
+[![Coverage
+Status](https://coveralls.io/repos/github/yast/yast-dns-server/badge.svg?branch=master)](https://coveralls.io/github/yast/yast-dns-server?branch=master)
 [![Travis Build](https://travis-ci.org/yast/yast-dns-server.svg?branch=master)](https://travis-ci.org/yast/yast-dns-server)
 [![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-dns-server-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-dns-server-master/)
 

--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Nov  6 11:55:43 UTC 2017 - knut.anderssen@suse.com
 
-- Fix teststuite once SuSEFirewall2 is bein replaced by Firewalld
+- Fix teststuite once SuSEFirewall2 is being replaced by Firewalld
   (fate#323460)
 - 4.0.0
 

--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov  6 11:55:43 UTC 2017 - knut.anderssen@suse.com
+
+- Fix teststuite once SuSEFirewall2 is bein replaced by Firewalld
+  (fate#323460)
+- 4.0.0
+
+-------------------------------------------------------------------
 Thu Nov 24 14:13:00 UTC 2016 - igonzalezsosa@suse.com
 
 - Remove dead code regarding help messages (bsc#1012048) 

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        3.2.0
+Version:        4.0.0
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 

--- a/testsuite/tests/Read.rb
+++ b/testsuite/tests/Read.rb
@@ -113,7 +113,6 @@ module Yast
 
       # avoid reading SuSEFirewall sysconfig
       Yast.import "SuSEFirewall"
-      SuSEFirewall.SuSEFirewall_variables = []
 
       @progress_orig = Progress.set(false)
 


### PR DESCRIPTION
- Almost the same we did for yast/yast-nfs-client#54