### PR TITLE
Reload the service only if it is running (bsc#1102235)

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 25 18:20:26 UTC 2018 - knut.anderssen@suse.com
+
+- Reload the configuration only if the service is running but do
+  not restart the service. (bsc#1102235)
+- 4.0.4
+
+-------------------------------------------------------------------
 Tue Jun 26 16:51:49 CEST 2018 - schubi@suse.de
 
 - Added additional searchkeys to desktop file (fate#321043).

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        4.0.3
+Version:        4.0.4
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 

--- a/src/include/dns-server/dialog-installwizard.rb
+++ b/src/include/dns-server/dialog-installwizard.rb
@@ -189,7 +189,6 @@ module Yast
             Left(
               RadioButtonGroup(
                 Id("dns_server_type"),
-                Opt(:shrinkable),
                 VBox(
                   # Radiobutton label - DNS starting
                   Left(

--- a/src/include/dns-server/dialog-main.rb
+++ b/src/include/dns-server/dialog-main.rb
@@ -1881,13 +1881,7 @@ module Yast
       Wizard.RestoreHelp(Ops.get_string(@HELPS, "write", ""))
       ret = DnsServer.Write
       if ret
-        if status_widget.reload_flag?
-          if service.running?
-            service.reload
-          else
-            service.restart
-          end
-        end
+        service.reload if service.running? && status_widget.reload_flag?
         :next
       else
         if Popup.YesNo(_("Saving the configuration failed. Change the settings?"))
@@ -1904,7 +1898,7 @@ module Yast
       Wizard.RestoreHelp(Ops.get_string(@HELPS, "write", ""))
       ret = DnsServer.Write
       if ret
-        service.reload if status_widget.reload_flag?
+        service.reload if service.running? && status_widget.reload_flag?
       else
         Report.Error(_("Saving the configuration failed"))
       end

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -23,22 +23,44 @@ describe "DnsServerDialogMainInclude" do
   end
 
   describe "#WriteDialog" do
-    it "reloads running named.service" do
-      m = CurrentDialogMain.new
-      expect(Yast::DnsServer).to receive(:Write).and_return true
-      expect(m.service).to receive(:running?).and_return true
-      expect(m.status_widget).to receive(:reload_flag?).and_return true
-      expect(m.service).to receive(:reload)
-      expect(m.WriteDialog ).to eq(:next)
+    context "when the named service is running" do
+      context "and the config is marked to be reloaded" do
+        it "reloads the service" do
+          m = CurrentDialogMain.new
+          expect(Yast::DnsServer).to receive(:Write).and_return true
+          expect(m.service).to receive(:running?).and_return true
+          expect(m.status_widget).to receive(:reload_flag?).and_return true
+          expect(m.service).to receive(:reload)
+          expect(m.WriteDialog ).to eq(:next)
+        end
+      end
+
+      context "and the config is not marked to be reloaded" do
+        it "does not restart nor reload the service" do
+          m = CurrentDialogMain.new
+          expect(Yast::DnsServer).to receive(:Write).and_return true
+          expect(m.service).to receive(:running?).and_return true
+          expect(m.status_widget).to receive(:reload_flag?).and_return false
+          expect(m.service).to_not receive(:reload)
+          expect(m.service).to_not receive(:restart)
+          expect(m.WriteDialog ).to eq(:next)
+        end
+      end
     end
 
-    it "restarts not running named.service" do
-      m = CurrentDialogMain.new
-      expect(Yast::DnsServer).to receive(:Write).and_return true
-      expect(m.service).to receive(:running?).and_return false
-      expect(m.status_widget).to receive(:reload_flag?).and_return true
-      expect(m.service).to receive(:restart)
-      expect(m.WriteDialog ).to eq(:next)
+    context "when the named service is not running" do
+      let(:m) { CurrentDialogMain.new }
+      before do
+        allow(m.status_widget).to receive(:reload_flag?).and_return true
+      end
+
+      it "does not restart nor reload the service" do
+        expect(Yast::DnsServer).to receive(:Write).and_return true
+        expect(m.service).to receive(:running?).and_return false
+        expect(m.service).to_not receive(:restart)
+        expect(m.service).to_not receive(:reload)
+        expect(m.WriteDialog ).to eq(:next)
+      end
     end
   end
 

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -23,43 +23,73 @@ describe "DnsServerDialogMainInclude" do
   end
 
   describe "#WriteDialog" do
-    context "when the named service is running" do
-      context "and the config is marked to be reloaded" do
-        it "reloads the service" do
-          m = CurrentDialogMain.new
-          expect(Yast::DnsServer).to receive(:Write).and_return true
-          expect(m.service).to receive(:running?).and_return true
-          expect(m.status_widget).to receive(:reload_flag?).and_return true
-          expect(m.service).to receive(:reload)
-          expect(m.WriteDialog ).to eq(:next)
+    let(:m) { CurrentDialogMain.new }
+    let(:written) { false }
+    let(:running) { true }
+
+    before do
+      allow(Yast::DnsServer).to receive(:Write).and_return written
+      allow(m.service).to receive(:running?).and_return running
+    end
+
+    it "writes the DNS configuration" do
+      expect(Yast::DnsServer).to receive(:Write).and_return written
+      m.WriteDialog
+    end
+
+    context "when the configuration is written" do
+      let(:written) { true }
+
+      context "and the named service is running" do
+        context "and the config is marked to be reloaded" do
+          it "reloads the service" do
+            expect(m.status_widget).to receive(:reload_flag?).and_return true
+            expect(m.service).to receive(:reload)
+            expect(m.WriteDialog ).to eq(:next)
+          end
+        end
+
+        context "and the config is not marked to be reloaded" do
+          it "does not restart nor reload the service" do
+            expect(m.status_widget).to receive(:reload_flag?).and_return false
+            expect(m.service).to_not receive(:reload)
+            expect(m.service).to_not receive(:restart)
+            expect(m.WriteDialog ).to eq(:next)
+          end
         end
       end
 
-      context "and the config is not marked to be reloaded" do
+      context "and the named service is not running" do
+        let(:running) { false}
+
+        before do
+          allow(m.status_widget).to receive(:reload_flag?).and_return true
+        end
+
         it "does not restart nor reload the service" do
-          m = CurrentDialogMain.new
-          expect(Yast::DnsServer).to receive(:Write).and_return true
-          expect(m.service).to receive(:running?).and_return true
-          expect(m.status_widget).to receive(:reload_flag?).and_return false
-          expect(m.service).to_not receive(:reload)
           expect(m.service).to_not receive(:restart)
+          expect(m.service).to_not receive(:reload)
           expect(m.WriteDialog ).to eq(:next)
         end
       end
     end
 
-    context "when the named service is not running" do
-      let(:m) { CurrentDialogMain.new }
-      before do
-        allow(m.status_widget).to receive(:reload_flag?).and_return true
+    context "when the configuration is not written" do
+      let(:written) { false }
+
+      it "aks for changing the current settings" do
+        expect(Yast::Popup).to receive(:YesNo)
+        m.WriteDialog
       end
 
-      it "does not restart nor reload the service" do
-        expect(Yast::DnsServer).to receive(:Write).and_return true
-        expect(m.service).to receive(:running?).and_return false
-        expect(m.service).to_not receive(:restart)
-        expect(m.service).to_not receive(:reload)
-        expect(m.WriteDialog ).to eq(:next)
+      it "returns :back if decided to change the current settings" do
+        expect(Yast::Popup).to receive(:YesNo).and_return true
+        expect(m.WriteDialog).to eq(:back)
+      end
+
+      it "returns :abort if canceled" do
+        expect(Yast::Popup).to receive(:YesNo).and_return false
+        expect(m.WriteDialog).to eq(:abort)
       end
     end
   end


### PR DESCRIPTION
- Trello Card: https://trello.com/c/wa1yoNRJ/159-ostumbleweed-p3-1102235-build-20180721-named-service-is-not-stopped-when-stopping-using-yast-dns-module
- bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1102235


If we would like to restart the service or reload if running always then should be enough to set the write_only flag to false [here](https://github.com/yast/yast-dns-server/blob/master/src/include/dns-server/wizards.rb#L55)

In case of the normal run, it is set to true giving the responsibility to the user about the service state while in case of the wizard run we set it to false having it in sync.