### PR TITLE
Moves the manage of start mode and service status from Perl to Ruby

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 14 07:46:55 UTC 2018 - dgonzalez@suse.com
+
+- Manage the start mode and service status directly from Ruby.
+- 4.1.1
+
+-------------------------------------------------------------------
 Tue Aug  7 12:14:35 UTC 2018 - dgonzalez@suse.com
 
 - Use CWM::ServiceWidget to manage the service status

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 

--- a/src/modules/DnsServer.pm
+++ b/src/modules/DnsServer.pm
@@ -1526,49 +1526,6 @@ sub Write {
 
     $ret = {};
 
-    if (Mode->auto() || Mode->config())
-    {
-        # named has to be started
-        if ($start_service)
-        {
-        my $success = 1;
-        if (! $write_only)
-        {
-            # named is running
-            if (Service->Status("named") == 0) {
-            y2milestone("Reloading service 'named'");
-            $success = Service->Reload("named")
-            } else {
-            y2milestone("Restarting service 'named'");
-            $success = Service->Restart("named")
-            }
-        }
-        Service->Enable ("named");
-        if (! $success)
-        {
-            # Cannot start service 'named', because of error that follows Error:.  Do not translate named.
-            Report->Error (__("Error occurred while starting service named.\n\n"));
-            $ok = 0;
-            # There's no 'named' running -> prevent from blocking DNS queries
-            $self->SetLocalForwarder("resolver") if GetLocalForwarder() eq "bind";
-            y2warning("Local forwarder set to: ".GetLocalForwarder());
-        }
-        }
-        # named has to be stopped
-        else
-        {
-        if (! $write_only)
-        {
-            y2milestone("Stopping service 'named'");
-            Service->Stop("named");
-            # There's no 'named' running. Reset dns forwarder again
-            $self->SetLocalForwarder("resolver") if GetLocalForwarder() eq "bind";
-            y2warning("Local forwarder set to: ".GetLocalForwarder());
-        }
-        Service->Disable ("named");
-        }
-    }
-
     # First run finished
     if ($ok and first_run())
     {


### PR DESCRIPTION
As an improvement of https://github.com/yast/yast-dns-server/pull/73

Also could be considered as part of https://trello.com/c/uAe4i9Ru/107-5-fate319428-allow-socket-activation-widget