### PR TITLE
Skip checking installed packages in mode test

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul  1 13:44:42 UTC 2019 - Knut Alejandro Anderssen González <knut.anderssen@suse.com>
+
+- Fixed failing old testsuite: do not depend on the environment,
+  skip bind absence in Mode.test() (bsc#1138668)
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:28:57 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 Summary:        YaST2 - DNS Server Configuration
@@ -35,7 +35,7 @@ BuildRequires:  yast2-perl-bindings
 BuildRequires:  yast2-testsuite
 BuildRequires:  rubygem(rspec)
 # Yast2::ServiceWidget
-BuildRequires:  yast2 >= 4.1.0
+BuildRequires:  yast2 >= 4.2.11
 
 Requires:       /usr/bin/host
 Requires:       perl-gettext

--- a/src/modules/DnsServer.pm
+++ b/src/modules/DnsServer.pm
@@ -1309,6 +1309,7 @@ sub update_forwarding {
 # when applying configuration in AutoYast config module
 sub check_and_install_package {
     my $self = shift;
+    return 1 if (Mode->test ());
     return 1 if (PackageSystem->Installed("bind"));
 
     my $installed = 0;

--- a/testsuite/tests/DnsServerAPI.rb
+++ b/testsuite/tests/DnsServerAPI.rb
@@ -84,32 +84,6 @@ module Yast
           }
         },
         "sysconfig" => {
-          "SuSEfirewall2"     => {
-            "FW_ALLOW_FW_TRACEROUTE"   => "yes",
-            "FW_AUTOPROTECT_SERVICES"  => "no",
-            "FW_DEV_DMZ"               => "",
-            "FW_DEV_EXT"               => "eth-id-00:c0:df:22:c6:a8",
-            "FW_DEV_INT"               => "",
-            "FW_IPSEC_TRUST"           => "no",
-            "FW_LOG_ACCEPT_ALL"        => "no",
-            "FW_LOG_ACCEPT_CRIT"       => "yes",
-            "FW_LOG_DROP_ALL"          => "no",
-            "FW_LOG_DROP_CRIT"         => "yes",
-            "FW_MASQUERADE"            => "no",
-            "FW_MASQ_NETS"             => "",
-            "FW_PROTECT_FROM_INTERNAL" => "yes",
-            "FW_ROUTE"                 => "no",
-            "FW_SERVICES_DMZ_IP"       => "",
-            "FW_SERVICES_DMZ_TCP"      => "",
-            "FW_SERVICES_DMZ_UDP"      => "",
-            "FW_SERVICES_EXT_IP"       => "",
-            "FW_SERVICES_EXT_RPC"      => "nlockmgr status nfs nfs_acl mountd ypserv fypxfrd ypbind ypasswdd",
-            "FW_SERVICES_EXT_TCP"      => "32768 5801 5901 dixie domain hostname microsoft-ds netbios-dgm netbios-ns netbios-ssn nfs ssh sunrpc",
-            "FW_SERVICES_EXT_UDP"      => "222 bftp domain ipp sunrpc",
-            "FW_SERVICES_INT_IP"       => "",
-            "FW_SERVICES_INT_TCP"      => "ddd eee fff 44 55 66",
-            "FW_SERVICES_INT_UDP"      => "aaa bbb ccc 11 22 33"
-          },
           "personal-firewall" => { "REJECT_ALL_INCOMING_CONNECTIONS" => "" },
           "network"           => {
             "config" => {


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1138668

## Problem
- Failing old testsuite in yast2-dns-server
- It depends on bind rpm installed.

## Fix

- Do not depend on the package installed at all in Mode.test()
- 4.2.1