### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ config.sub
 configure
 /configure.in
 configure.ac
+coverage/
+doc/
 depcomp
 install-sh
 missing
@@ -26,3 +28,4 @@ pluglib-bindings.ami
 test-driver
 /test/*.log
 /test/*.trs
+.yardoc/


### PR DESCRIPTION
Just to make [Travis](https://travis-ci.org/yast/yast-dns-server/builds/560902333) happy again :)

```
rake aborted!
New files missing in git (or add them to to .gitignore):
.yardoc/checksums
.yardoc/object_types
.yardoc/objects/root.dat
.yardoc/proxy_types
coverage/.last_run.json
coverage/.resultset.json
coverage/.resultset.json.lock
...
```