### PR TITLE
Fix wizard service save (bsc#1123985)

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 20 14:12:10 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not modify the service when finishing the wizard dialog as
+  the configuration has not been written yet. (bsc#1123985)
+- 4.1.3
+
+-------------------------------------------------------------------
 Sun Nov 25 02:10:40 UTC 2018 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        4.1.2
+Version:        4.1.3
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 

--- a/src/include/dns-server/dialog-installwizard.rb
+++ b/src/include/dns-server/dialog-installwizard.rb
@@ -28,14 +28,6 @@ module Yast
       Yast.import "CWMFirewallInterfaces"
     end
 
-    # Writes settings and saves the service
-    #
-    # @return [Boolean] true if service is saved successfully; false otherwise
-    def write_dns_settings
-      service_widget.store
-      service.save
-    end
-
     def runInstallWizardForwardersDialog
       caption =
         # Dialog caption (before a colon)
@@ -261,7 +253,7 @@ module Yast
       end
 
       if ret == :next || ret == :expert
-        write_dns_settings
+        service_widget.store
 
         CWMFirewallInterfaces.OpenFirewallStore(firewall_widget, "", event)
       end


### PR DESCRIPTION
- https://trello.com/c/lFP0akAB/1280-3-sle15-sp1-p2-1123985-build-1564-openqa-test-fails-in-yast2dnsserver-with-error-attention-etc-namedd-forwardersconf-is-not-a-li

## Problem

*The first time that the yast2 dns-server client is running and if the service is set to be started. Then, it reports an error because the '/etc/named.d/forwarders.conf' is not a link to '/var/run/netconfig/bind-forwarders.conf'

- *https://bugzilla.suse.com/show_bug.cgi?id=1123985*
- *https://openqa.opensuse.org/tests/930731#step/yast2_dns_server/21*

## Solution

*Do not touch the service when finishing the wizard sequence but after writing the DNS configuration*

**Note**: Asking the user for forcing an update would be nice.

## Testing

- *Tested manually*
