### PR TITLE
Permit the user to force an update if wanted so.

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 23 07:12:04 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Permit the user to force an netconfig update when netconfig was
+  not able to change the configuration. (bsc#1123985)
+- 4.1.4
+
+-------------------------------------------------------------------
 Fri Sep 20 14:12:10 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not modify the service when finishing the wizard dialog as

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-dns-server
 #
-# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -12,7 +12,7 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
 

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        4.1.3
+Version:        4.1.4
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 

--- a/src/modules/DnsServer.pm
+++ b/src/modules/DnsServer.pm
@@ -1262,7 +1262,7 @@ sub GetWhichZonesAreConnectedWith {
 
 sub netconfig_update_dns {
     my $force_update = shift;
-    my $cmd = "/sbin/netconfig".($force_update ? " -f":"")." update -m dns";
+    my $cmd = "/sbin/netconfig".($force_update ? " -f" : "")." update -m dns";
 
     y2milestone("Updating forwarders by netconfig");
 

--- a/src/modules/DnsServer.pm
+++ b/src/modules/DnsServer.pm
@@ -1260,6 +1260,20 @@ sub GetWhichZonesAreConnectedWith {
     return \@ret;
 }
 
+sub netconfig_update_dns {
+    my $force_update = shift;
+    my $cmd = "/sbin/netconfig".($force_update ? " -f":"")." update -m dns";
+
+    y2milestone("Updating forwarders by netconfig");
+
+    my $ret = SCR->Execute (".target.bash_output", $cmd);
+    if ($ret->{'exit'} != 0) {
+      Report->Error (sformat(__("Error occurred while calling netconfig.\nError: %1"), $ret->{'stdout'}));
+    }
+
+    return $ret->{'exit'};
+}
+
 # Writes forwarding settings and updates the system using netconfig.
 # This also automatically updates /etc/named.d/forwarders.conf
 sub write_local_forwarder {
@@ -1269,10 +1283,11 @@ sub write_local_forwarder {
     SCR->Write (".sysconfig.network.config.NETCONFIG_DNS_FORWARDER", GetLocalForwarder());
     SCR->Write (".sysconfig.network.config", undef);
 
-    y2milestone("Updating forwarders by netconfig");
-    my $ret = SCR->Execute (".target.bash_output", "/sbin/netconfig update -m dns");
-    if ($ret->{'exit'} != 0) {
-        Report->Error (__("Error occurred while calling netconfig.\nError: ".$ret->{'stdout'}));
+    my $netconfig_dns_updated = netconfig_update_dns(0);
+
+    if ($netconfig_dns_updated == 20) {
+      my $retry = Popup->YesNo (__("Do you want to force an update now?"));
+      netconfig_update_dns(1) if ($retry);
     }
 }
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1123985

When netconfig is not able to update the configuration because it was modified since the last run, the client report the error but does not permit to force an update having to do it manually.

![UpdateError](https://user-images.githubusercontent.com/7056681/65407462-7fe78880-ddda-11e9-9fab-581fe4f6bc70.png)

## Solution

Permit the user to force an update after the error report.

![UpdateNow](https://user-images.githubusercontent.com/7056681/65407466-82e27900-ddda-11e9-94e4-f49d7695bfa7.png)
