### PR TITLE
AutoYaST: Added supplements: autoyast(dns-server) into the spec file …

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Aug 10 12:40:23 CEST 2020 - schubi@suse.de
+
+- AutoYaST: Added supplements: autoyast(dns-server) into the spec file
+  in order to install this packages if the section has been defined
+  in the AY configuration file (bsc#1146494).
+- 4.3.1
+
+-------------------------------------------------------------------
 Thu May  7 15:31:44 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Autoyast schema: Allow optional types for string and map objects

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 Summary:        YaST2 - DNS Server Configuration
@@ -57,6 +57,8 @@ Requires:       yast2-sysconfig
 # Yast2::ServiceWidget
 Requires:       yast2 >= 4.1.0
 Requires:       yast2-ruby-bindings >= 1.0.0
+
+Supplements:    autoyast(dns-server)
 
 BuildArch:      noarch
 


### PR DESCRIPTION
…in order to install this packages if the section has been defined in the AY configuration file (bsc#1146494).