### PR TITLE
Adapt unit test to recent changes in Yast::Report

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 18 16:18:21 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.2
+
+-------------------------------------------------------------------
 Mon Aug 10 12:40:23 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(dns-server) into the spec file

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 Summary:        YaST2 - DNS Server Configuration

--- a/test/dns_server_ui_test.rb
+++ b/test/dns_server_ui_test.rb
@@ -9,19 +9,23 @@ describe Yast::DnsServerUI do
 
   # Direct translation to RSpec of equivalent tests from the old testsuite
   describe "#ChangeIPToLocalEquivalent" do
-    it "transforms private IPv4 addresses" do
+    it "transforms private IPv4 addresses and reports the change to the user" do
+      expect(Yast::Report).to receive(:Warning).with(/changed to its local equivalent/)
       expect(subject.ChangeIPToLocalEquivalent("192.168.5.1")).to eq "127.0.0.1"
     end
 
-    it "transforms public IPv4 addresses" do
+    it "transforms public IPv4 addresses and reports the change to the user" do
+      expect(Yast::Report).to receive(:Warning).with(/changed to its local equivalent/)
       expect(subject.ChangeIPToLocalEquivalent("238.11.26.25")).to eq "127.0.0.1"
     end
 
-    it "transforms IPv6 addresses" do
+    it "transforms IPv6 addresses and reports the change to the user" do
+      expect(Yast::Report).to receive(:Warning).with(/changed to its local equivalent/)
       expect(subject.ChangeIPToLocalEquivalent("fe80::21c:c0ff:fe18:f01c")).to eq "::1"
     end
 
-    it "returns nil for invalid IPs" do
+    it "returns nil and reports an error for invalid IPs" do
+      expect(Yast::Report).to receive(:Error)
       expect(subject.ChangeIPToLocalEquivalent("trash")).to be_nil
     end
   end


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-autoinstallation, yast-add-on, yast-bootloader, yast-configuration-management, yast-dns-server, yast-installation, yast-kdump, yast-network, yast-nfs-client, yast-ntp-client, yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager, yast-samba-server, yast-packager, yast-registration and yast-sysconfig.

This should fix the problem for this repository.