### PR TITLE
Zones list validation

### DIFF
--- a/package/yast2-dns-server.changes
+++ b/package/yast2-dns-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar  3 15:29:24 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: allow using 'zone' instead of 'listentry' in the
+  list of zones (bsc#1181718).
+- 4.3.3
+
+-------------------------------------------------------------------
 Thu Feb 18 16:18:21 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Adapted unit test to recent changes in Yast::Report (related to

--- a/package/yast2-dns-server.spec
+++ b/package/yast2-dns-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-dns-server
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Url:            https://github.com/yast/yast-dns-server
 Summary:        YaST2 - DNS Server Configuration

--- a/src/autoyast-rnc/dns-server.rnc
+++ b/src/autoyast-rnc/dns-server.rnc
@@ -60,7 +60,7 @@ dns-server_zones = element zones {
     dns-server_zones_entry*
 }
 
-dns-server_zones_entry = element listentry {
+dns-server_zones_entry = element (zone | listentry) {
     MAP,
     (
       element is_new       { ONE_ZERO }? &


### PR DESCRIPTION
Allow using `zone` instead of `listentry`.

Bug: [bsc#1181718](https://bugzilla.suse.com/show_bug.cgi?id=1181718).